### PR TITLE
Fall back to manual input if shell command takes too long

### DIFF
--- a/app/run.py
+++ b/app/run.py
@@ -3,6 +3,7 @@ import os
 import sys
 
 from PyQt5.QtWidgets import QApplication
+from PyQt5.QtCore import QTimer
 
 from app.core import files
 from app.logsmith import MainWindow
@@ -37,9 +38,15 @@ def main():
 
     logging.info(f'config dir {app_path}')
     logging.info('start app')
+
     try:
         app = QApplication(sys.argv)
         MainWindow(app)
+
+        timer = QTimer()
+        timer.timeout.connect(lambda: None)
+        timer.start(100)
+
         sys.exit(app.exec_())
     except Exception:
         logging.error('unexpected error', exc_info=True)

--- a/app/shell/shell.py
+++ b/app/shell/shell.py
@@ -5,16 +5,19 @@ import subprocess as sp
 logger = logging.getLogger('logsmith')
 
 
-def run(command):
+def run(command, timeout=3):
     proc = None
     try:
         proc = sp.run(shlex.split(command),
                       stdout=sp.PIPE,
                       stderr=sp.PIPE,
-                      timeout=3,
+                      timeout=timeout,
                       universal_newlines=True)
         proc.check_returncode()
         return proc.stdout.rstrip()
+    except sp.TimeoutExpired:
+        logger.warning(f'command {command} took too long and was aborted')
+        return None
     except FileNotFoundError:
         logger.warning(f'command {command} not found')
         return None

--- a/tests/test_resources/timeout.sh
+++ b/tests/test_resources/timeout.sh
@@ -1,0 +1,4 @@
+#!/usr/bin/env bash
+SLEEP_TIME=10
+echo "this will wait for $SLEEP_TIME seconds"
+sleep $SLEEP_TIME

--- a/tests/test_shell/test_shell.py
+++ b/tests/test_shell/test_shell.py
@@ -5,7 +5,6 @@ from app.shell import shell
 
 script_dir = os.path.dirname(os.path.realpath(__file__))
 
-
 class Test(TestCase):
     def test_run(self):
         self.assertEqual('test', shell.run('echo test'))
@@ -14,5 +13,7 @@ class Test(TestCase):
         self.assertEqual(None, shell.run('this_commando_does_not_exist'))
 
     def test_run__command_error(self):
-        self.assertEqual(None, shell.run(f'{script_dir}/test_resources/fail.sh'))
+        self.assertEqual(None, shell.run(f'{script_dir}/../test_resources/fail.sh'))
 
+    def test_run__command_timeout(self):
+        self.assertEqual(None, shell.run(f'{script_dir}/../test_resources/timeout.sh', 1))


### PR DESCRIPTION
When the shell command is taking more than 3 seconds, it will produce an exception that is not handled and crash the logsmith process.

This commit will prevent the crash and allow to fallback to manual input as if the command line had returned a failure code, together with a test that proves this behaviour.

As well, I'd like logsmith to actually abort if I Ctrl-C in the command line, so now there's a tiny interrupt in QT's event loop, allowing the main thread to react to keystrokes.