### PR TITLE
Introduce some basic command line arguments

### DIFF
--- a/app/__version__.py
+++ b/app/__version__.py
@@ -1,1 +1,2 @@
 __version__ = (4, 1, 0)
+__version_string__ = '.'.join(str(i) for i in __version__)

--- a/app/core/arguments.py
+++ b/app/core/arguments.py
@@ -1,0 +1,15 @@
+from argparse import ArgumentParser
+
+from app import __version__
+
+
+def parse(args):
+    parser = ArgumentParser(prog='logsmith')
+    parser.add_argument("-l", "--loglevel", dest="loglevel", default="WARN",
+                        choices=['DEBUG', 'INFO', 'WARN', 'ERROR', 'FATAL'],
+                        help="set the loglevel")
+    parser.add_argument('-v', '--version', action='version',
+                version="{prog}s {version}".format(prog="%(prog)", version=__version__.__version_string__))
+
+    return parser.parse_args(args)
+

--- a/app/gui/config_dialog.py
+++ b/app/gui/config_dialog.py
@@ -16,8 +16,7 @@ class ConfigDialog(QDialog):
         super(ConfigDialog, self).__init__(parent)
         self.parent = parent
 
-        version = '.'.join(str(i) for i in __version__.__version__)
-        self.setWindowTitle(f'Config - v{version}')
+        self.setWindowTitle(f'Config - v{__version__.__version_string__}')
         self.initial_width = 600
         self.initial_height = 600
         self.resize(self.initial_width, self.initial_height)

--- a/app/run.py
+++ b/app/run.py
@@ -5,7 +5,7 @@ import sys
 from PyQt5.QtWidgets import QApplication
 from PyQt5.QtCore import QTimer
 
-from app.core import files
+from app.core import files, arguments
 from app.logsmith import MainWindow
 
 
@@ -22,7 +22,8 @@ def main():
     if not os.path.exists(aws_path):
         os.mkdir(aws_path)
 
-    logging.basicConfig(level=logging.WARNING)
+    args = arguments.parse(sys.argv[1:])
+    logging.basicConfig(level=logging.getLevelName(args.loglevel))
     logger = logging.getLogger('logsmith')
     logger.propagate = False
     logger.setLevel(logging.DEBUG)

--- a/run.sh
+++ b/run.sh
@@ -15,4 +15,4 @@ if [[ ! -d ./venv/ ]]; then
     ./setup.sh
 fi
 export PYTHONPATH=${PYTHONPATH}:${DIR}
-./venv/bin/python ./app/run.py
+./venv/bin/python ./app/run.py ${@}

--- a/tests/test_core/test_arguments.py
+++ b/tests/test_core/test_arguments.py
@@ -1,0 +1,79 @@
+import contextlib
+import io
+from unittest import TestCase
+
+import sys
+
+from app.core import arguments
+from app import __version__
+
+
+@contextlib.contextmanager
+def captured_output():
+    new_out, new_err = io.StringIO(), io.StringIO()
+    old_out, old_err = sys.stdout, sys.stderr
+    try:
+        sys.stdout, sys.stderr = new_out, new_err
+        yield sys.stdout, sys.stderr
+    finally:
+        sys.stdout, sys.stderr = old_out, old_err
+
+class Test(TestCase):
+
+    def test_version_short(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(["-v"])
+
+        self.assertEqual(err.getvalue(), '')
+        self.assertEqual(out.getvalue(), 'logsmith {0}\n'.format(__version__.__version_string__))
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_version_long(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(["--version"])
+
+        self.assertEqual(err.getvalue(), '')
+        self.assertEqual(out.getvalue(), 'logsmith {0}\n'.format(__version__.__version_string__))
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_help_short(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(["-h"])
+
+        self.assertEqual(err.getvalue(), '')
+        self.assertRegex(out.getvalue(), "^usage: logsmith \\[-h\\].*")
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_help_long(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(["--help"])
+
+        self.assertEqual(err.getvalue(), '')
+        self.assertRegex(out.getvalue(), "^usage: logsmith \\[-h\\].*")
+        self.assertEqual(cm.exception.code, 0)
+
+    def test_loglevel_default(self):
+        args = arguments.parse([])
+        self.assertEqual(args.loglevel, 'WARN')
+
+    def test_loglevel_valid(self):
+        args = arguments.parse(['-l', 'INFO'])
+        self.assertEqual(args.loglevel, 'INFO')
+
+    def test_loglevel_invalid(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(['-l', 'LOTS'])
+
+        self.assertRegex(err.getvalue(), "logsmith: error: argument -l/--loglevel: invalid choice")
+        self.assertEqual(out.getvalue(), '')
+        self.assertNotEqual(cm.exception.code, 0)
+
+    def test_unknown_parameter(self):
+        with self.assertRaises(SystemExit) as cm, captured_output() as (out, err):
+            arguments.parse(['--foobar'])
+
+        self.assertRegex(err.getvalue(), "logsmith: error: unrecognized arguments: --foobar")
+        self.assertEqual(out.getvalue(), '')
+        self.assertNotEqual(cm.exception.code, 0)
+
+


### PR DESCRIPTION
For skripted updates, we wanted to be able to get logsmith's current version.

For more details, see the --help message:

usage: logsmith [-h] [-l {DEBUG,INFO,WARN,ERROR,FATAL}] [-v]

optional arguments:
  -h, --help            show this help message and exit
  -l {DEBUG,INFO,WARN,ERROR,FATAL}, --loglevel {DEBUG,INFO,WARN,ERROR,FATAL}
                        set the loglevel
  -v, --version         show program's version number and exit