### PR TITLE
fix: show dialogs in front

### DIFF
--- a/app/gui/access_key_dialog.py
+++ b/app/gui/access_key_dialog.py
@@ -98,6 +98,7 @@ class SetKeyDialog(QDialog):
         self.key_id_input.repaint()
         self.set_error_text(message)
         self.show()
+        self.raise_()
         self.activateWindow()
 
 

--- a/app/gui/config_dialog.py
+++ b/app/gui/config_dialog.py
@@ -125,6 +125,7 @@ class ConfigDialog(QDialog):
         self.update_error_text(config)
         self.mfa_command_input.setText(config.mfa_shell_command)
         self.show()
+        self.raise_()
         self.activateWindow()
 
 

--- a/app/gui/key_rotation_dialog.py
+++ b/app/gui/key_rotation_dialog.py
@@ -60,6 +60,7 @@ class RotateKeyDialog(QDialog):
 
     def show_dialog(self):
         self.show()
+        self.raise_()
         self.activateWindow()
 
 

--- a/app/gui/mfa_dialog.py
+++ b/app/gui/mfa_dialog.py
@@ -63,6 +63,7 @@ class MfaDialog(QDialog):
 
     def get_mfa_token(self):
         self.exec()
+        self.raise_()
         self.activateWindow()
         if self.pressed_cancel:
             return None


### PR DESCRIPTION
Opens & shows dialogs always on top of parent window.

Works in debug mode. Has to be tested with packaged version, too.