### PR TITLE
Show logsmith version in tray menu

### DIFF
--- a/app/gui/trayicon.py
+++ b/app/gui/trayicon.py
@@ -3,6 +3,7 @@ from typing import List, TYPE_CHECKING
 
 from PyQt6.QtWidgets import QSystemTrayIcon, QMenu
 
+from app.__version__ import __version_string__
 from app.aws import regions
 from app.core.profile_group import ProfileGroup
 from app.core.toggles import Toggles
@@ -126,6 +127,10 @@ class SystemTrayIcon(QSystemTrayIcon):
         menu.addMenu(self.copy_id_menu)
 
         menu.addSeparator()
+        self.version_action = menu.addAction(f"Version: {__version_string__}")
+        self.version_action.setDisabled(True)
+        menu.addSeparator()
+
         # exit
         exit_action = menu.addAction("Exit")
         exit_action.triggered.connect(self.gui.stop_and_exit)


### PR DESCRIPTION
In this PR I propose, showing the logsmith version to the tray menu. 
Quite often I'm not sure what logsmith version I was using or if it is the newest one, since as far as I know there is no way of checking the logsmith version. With this change the user now sees the version at the bottom above the `exit` option.

<img width="290" height="788" alt="Screenshot 2025-08-06 at 12 02 41" src="https://github.com/user-attachments/assets/5fa4e846-5bd5-401f-8010-b376d47bcdb1" />
