### PR TITLE
add error output of external shell commands to log

### DIFF
--- a/app/shell/shell.py
+++ b/app/shell/shell.py
@@ -68,6 +68,8 @@ def run(command, timeout=5) -> Result:
     if proc is not None:
         logger.info(f'--- shell output start ---\n{proc.stdout.rstrip()}')
         logger.info(f'--- shell output end ---')
+        logger.info(f'--- shell error start ---\n{proc.stderr.rstrip()}')
+        logger.info(f'--- shell error end ---')
     else:
         logger.info(f'--- no shell output ---')
         


### PR DESCRIPTION
If external shell commands like mfa token retrieval or aws sso login fail, there may be no output in the logsmith log because the stderr stream of the command is not added to the log.

This PR also adds stderr to the shell output. This would improve error analysis.