### PR TITLE
[bashism] Fix/sso unset fish compat

### DIFF
--- a/app/aws/sso.py
+++ b/app/aws/sso.py
@@ -250,13 +250,13 @@ def sso_login(profile_group: ProfileGroup) -> Result:
     # unset AWS_PROFILE and AWS_DEFAULT_PROFILE because sso login fails is profile is present
     # or aborts when profiles are not found.
     return shell.run(
-        command=f"unset AWS_PROFILE && unset AWS_DEFAULT_PROFILE && aws sso login --sso-session {sso_session_name}",
+        command=f"env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE aws sso login --sso-session {sso_session_name}",
         timeout=600,
     )
 
 
 def sso_logout() -> Result:
     return shell.run(
-        command=f"unset AWS_PROFILE && unset AWS_DEFAULT_PROFILE && aws sso logout",
+        command=f"env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE aws sso logout",
         timeout=600,
     )

--- a/tests/test_aws/test_sso.py
+++ b/tests/test_aws/test_sso.py
@@ -583,7 +583,7 @@ def test_sso_login(mocker):
     result = sso.sso_login(profile_group)
 
     expected_command = (
-        "unset AWS_PROFILE && unset AWS_DEFAULT_PROFILE && aws sso login --sso-session specific-sso-session"
+        "env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE aws sso login --sso-session specific-sso-session"
     )
     mock_shell_run.assert_called_once_with(command=expected_command, timeout=600)
     assert result.was_success
@@ -594,7 +594,7 @@ def test_sso_logout(mocker):
 
     result = sso.sso_logout()
 
-    expected_command = "unset AWS_PROFILE && unset AWS_DEFAULT_PROFILE && aws sso logout"
+    expected_command = "env -u AWS_PROFILE -u AWS_DEFAULT_PROFILE aws sso logout"
     mock_shell_run.assert_called_once_with(command=expected_command, timeout=600)
     assert result.was_success
 


### PR DESCRIPTION
unset is a bash built-in and fails in fish with exit 127. Use 'env -u VAR cmd' instead, which is an external binary that works in any login shell.

